### PR TITLE
Capitalize account names no more than necessary

### DIFF
--- a/g2b/g2b.py
+++ b/g2b/g2b.py
@@ -245,7 +245,7 @@ class GnuCash2Beancount:
         capitalized = [p[:1].upper() + p[1:] if p else "" for p in components]
         account_name = ":".join(capitalized)
 
-        return account_name.title()
+        return account_name
 
     def _sanitize_description(self, description) -> str:
         """Removes unwanted characters from a transaction narration"""

--- a/g2b/g2b.py
+++ b/g2b/g2b.py
@@ -236,11 +236,15 @@ class GnuCash2Beancount:
     def _apply_renaming_patterns(self, account_name):
         """
         Renames an account such that it complies with the required beancount format.
-        The naming is also being capitalized here such that always only the first latter is written
-        in capitals.
+        It also makes sure that the first letter of every component is capitalized.
         """
         for pattern, replacement in self._account_rename_patterns:
             account_name = re.sub(pattern, repl=replacement, string=account_name)
+
+        components = account_name.split(":")
+        capitalized = [p[:1].upper() + p[1:] if p else "" for p in components]
+        account_name = ":".join(capitalized)
+
         return account_name.title()
 
     def _sanitize_description(self, description) -> str:

--- a/tests/test_g2b.py
+++ b/tests/test_g2b.py
@@ -139,7 +139,7 @@ class TestGnuCash2Beancount:
         with open(output_path, "r", encoding="utf8") as beanfile:
             content = beanfile.read()
         example_transaction = """2024-05-06 ! "Transfer"
-  ! Assets:Current-Assets:Checkingaccount-Foo-Bank   1000.0 EUR
+  ! Assets:Current-Assets:CheckingAccount-Foo-Bank   1000.0 EUR
   ! Assets:Current-Assets:Checking-Account          -1000.0 EUR
 """
         assert example_transaction in content
@@ -168,21 +168,21 @@ class TestGnuCash2Beancount:
             data.Open(
                 meta={"filename": PosixPath(self.gnucash_path), "lineno": -1},
                 date=datetime.datetime(2024, 5, 3).date(),
-                account="Expenses:Mygroceries",
+                account="Expenses:MyGroceries",
                 currencies=["EUR"],
                 booking=None,
             ),
             data.Open(
                 meta={"filename": PosixPath(self.gnucash_path), "lineno": -1},
                 date=datetime.datetime(2024, 5, 6).date(),
-                account="Assets:Current-Assets:Checkingaccount-Foo-Bank",
+                account="Assets:Current-Assets:CheckingAccount-Foo-Bank",
                 currencies=["EUR"],
                 booking=None,
             ),
             data.Open(
                 meta={"filename": PosixPath(self.gnucash_path), "lineno": -1},
                 date=datetime.datetime(2024, 5, 9).date(),
-                account="Assets:Current-Assets:Wallet-Nzd",
+                account="Assets:Current-Assets:Wallet-NZD",
                 currencies=["NZD"],
                 booking=None,
             ),
@@ -233,7 +233,7 @@ class TestGnuCash2Beancount:
                 links=set(),
                 postings=[
                     data.Posting(
-                        account="Expenses:Mygroceries",
+                        account="Expenses:MyGroceries",
                         units=amount.Amount(D("120.0"), currency="EUR"),
                         cost=None,
                         price=None,
@@ -260,7 +260,7 @@ class TestGnuCash2Beancount:
                 links=set(),
                 postings=[
                     data.Posting(
-                        account="Assets:Current-Assets:Checkingaccount-Foo-Bank",
+                        account="Assets:Current-Assets:CheckingAccount-Foo-Bank",
                         units=amount.Amount(D("1000.0"), currency="EUR"),
                         cost=None,
                         price=None,
@@ -287,7 +287,7 @@ class TestGnuCash2Beancount:
                 links=set(),
                 postings=[
                     data.Posting(
-                        account="Assets:Current-Assets:Wallet-Nzd",
+                        account="Assets:Current-Assets:Wallet-NZD",
                         units=amount.Amount(D("50.0"), currency="NZD"),
                         cost=None,
                         price=None,


### PR DESCRIPTION
Currently, the converter is too aggressive in changing capitalization of account names. For example, it changes "Chase checking account USD" to "Chase-Checking-Account-Usd". This is not strictly required by the beancount specification at https://beancount.github.io/docs/beancount_language_syntax.html#accounts and in many cases reduces the readability of account names. For example if an account name component for your Google stocks is GOOGL, it changes it to Googl. Also, if you have separate accounts for different currencies, it changes currency names from all caps (USD) to Title Case (Usd).

This change makes sure that only the first letter of every account name component is capitalized, if it is not already a capital letter. Components are the names between colons. This means that "Chase checking account USD" becomes "Chase-checking-account-USD" which is a valid account name component and preserves the readability of the original GnuCash account.